### PR TITLE
fix: use repository owner for package rollback

### DIFF
--- a/.github/workflows/bump-major-version.yml
+++ b/.github/workflows/bump-major-version.yml
@@ -9,6 +9,6 @@ on:
 
 jobs:
   bump:
-    uses: kungfu-systems/workflows/.github/workflows/.bump-major-version.yml@v2.0-alpha
+    uses: kungfu-systems/workflows/.github/workflows/.bump-major-version.yml@v2
     secrets:
       GITHUB_PUSH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/.github/workflows/bump-minor-version.yml
+++ b/.github/workflows/bump-minor-version.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   bump:
-    uses: kungfu-systems/workflows/.github/workflows/.bump-minor-version.yml@v2.0-alpha
+    uses: kungfu-systems/workflows/.github/workflows/.bump-minor-version.yml@v2
     secrets:
       GITHUB_PUSH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -15,10 +15,10 @@ permissions:
 
 jobs:
   release:
-    uses: kungfu-systems/workflows/.github/workflows/.release-new-version.yml@v2.0-alpha
+    uses: kungfu-systems/workflows/.github/workflows/.release-new-version.yml@v2
     with:
       publish-aws-ci: false
       publish-aws-user: false
-      action-bump-version-ref: v4.0-alpha
+      action-bump-version-ref: v4
     secrets:
       GITHUB_PUSH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   try:
-    uses: kungfu-systems/workflows/.github/workflows/.release-verify.yml@v2.0-alpha
+    uses: kungfu-systems/workflows/.github/workflows/.release-verify.yml@v2
     with:
       prebuild: false
       build-container-enabled: false
@@ -21,7 +21,7 @@ jobs:
       publish-versioning: false
       publish-aws-ci: false
       publish-aws-user: false
-      action-bump-version-ref: v4.0-alpha
+      action-bump-version-ref: v4
   verify:
     needs: try
     runs-on: ubuntu-24.04

--- a/dist/index.js
+++ b/dist/index.js
@@ -203,7 +203,7 @@ exports.deletePublishedPackages = async function (argv, info) {
   const res = await octokit.rest.packages.getAllPackageVersionsForPackageOwnedByOrg({
     package_type: 'npm',
     package_name: info.names,
-    org: 'kungfu-trader',
+    org: argv.owner,
   });
   packageVersion = res.data[0].name;
   console.log(`| Version [${info.delVersion}] needs to be deleted |`);
@@ -213,7 +213,7 @@ exports.deletePublishedPackages = async function (argv, info) {
     const delete_pkg = await octokit.rest.packages.deletePackageVersionForOrg({
       package_type: 'npm',
       package_name: info.names,
-      org: 'kungfu-trader',
+      org: argv.owner,
       package_version_id: res.data[0].id,
     });
     console.log(`[Sucess!] Already has deleted package [${info.names}] with version [${info.delVersion}] \n`);

--- a/lib.js
+++ b/lib.js
@@ -197,7 +197,7 @@ exports.deletePublishedPackages = async function (argv, info) {
   const res = await octokit.rest.packages.getAllPackageVersionsForPackageOwnedByOrg({
     package_type: 'npm',
     package_name: info.names,
-    org: 'kungfu-trader',
+    org: argv.owner,
   });
   packageVersion = res.data[0].name;
   console.log(`| Version [${info.delVersion}] needs to be deleted |`);
@@ -207,7 +207,7 @@ exports.deletePublishedPackages = async function (argv, info) {
     const delete_pkg = await octokit.rest.packages.deletePackageVersionForOrg({
       package_type: 'npm',
       package_name: info.names,
-      org: 'kungfu-trader',
+      org: argv.owner,
       package_version_id: res.data[0].id,
     });
     console.log(`[Sucess!] Already has deleted package [${info.names}] with version [${info.delVersion}] \n`);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@kungfu-trader/action-rollback-release",
   "version": "1.0.1-alpha.0",
   "main": "dist/index.js",
-  "repository": "https://github.com/kungfu-trader/action-rollback-release",
+  "repository": "https://github.com/kungfu-systems/action-rollback-release",
   "author": "Keren Dong",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
## Summary
- replace hardcoded GitHub Packages org with the runtime repository owner
- keep package names and release behavior otherwise unchanged

## Validation
- yarn build
- actionlint -color=false $(rg --files --hidden .github/workflows -g '*.yml')
- git diff --check HEAD
- targeted scan for hardcoded GitHub owner/org returned no matches